### PR TITLE
Update CanalMessageDeserializer.java

### DIFF
--- a/client/src/main/java/com/alibaba/otter/canal/client/CanalMessageDeserializer.java
+++ b/client/src/main/java/com/alibaba/otter/canal/client/CanalMessageDeserializer.java
@@ -32,10 +32,12 @@ public class CanalMessageDeserializer {
                         if (lazyParseEntry) {
                             // byteString
                             result.setRawEntries(messages.getMessagesList());
+                            result.setRaw(true);
                         } else {
                             for (ByteString byteString : messages.getMessagesList()) {
                                 result.addEntry(CanalEntry.Entry.parseFrom(byteString));
                             }
+                            result.setRaw(false);
                         }
                         return result;
                     }


### PR DESCRIPTION
修复CanalMessageDeserializer.deserializer方法，在lazyParseEntry =  false 情况下，没有修改raw的值（因为raw默认值是true），导致后续如果用FlatMessage.messageConverter转换不出来的问题。